### PR TITLE
Updated cmakelist to remove interface warning, fixed warning function…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ MakefileInc.mk
 doc/
 build*
 *.swp
+CMakeFiles*
+CMakeCache*

--- a/KMC/CMakeLists.txt
+++ b/KMC/CMakeLists.txt
@@ -9,7 +9,7 @@ set(TARGET "kmcx")
 #add_library(${TARGET} STATIC ${SOURCES})
 add_library(${TARGET} INTERFACE)
 target_link_libraries(${TARGET} ${LIB})
-target_include_directories(${TARGET} PUBLIC INTERFACE
+target_include_directories(${TARGET} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:include/${TARGET}>

--- a/KMC/lookup_table.hpp
+++ b/KMC/lookup_table.hpp
@@ -166,7 +166,7 @@ class LookupTable {
 
         // clamp to grid bound
         if (rowIndex < 0 || colIndex < 0) {
-          warning("distPerp/sbound too small warning: %g/%g \n", distPerp, sbound);
+          printf("distPerp/sbound too small warning: %g/%g \n", distPerp, sbound);
           return 0.0;
         }
         if (rowIndex < 0) {


### PR DESCRIPTION
* Changed warning() function to printf() since we don't have warning defined in kmcx.
* Fixed interface bug from CMakeLists.txt by removing a misplaced PUBLIC declaration.